### PR TITLE
Reduce length of comment to comply with Fortran standard.

### DIFF
--- a/dom/m_dom_dom.F90
+++ b/dom/m_dom_dom.F90
@@ -9717,7 +9717,8 @@ endif
       endif
     endif
 
-! FIXME what if namespace is undeclared? Throw an error *only* if FoX_errors is on, otherwise its taken care of by namespace fixup on serialization
+! FIXME what if namespace is undeclared? Throw an error *only* if FoX_errors is
+! on, otherwise its taken care of by namespace fixup on serialization
 
     quickFix = getGCstate(getOwnerDocument(arg)) &
       .and. arg%inDocument


### PR DESCRIPTION
If you compile FoX_dom with the Intel compiler, it throws a warning on m_dom_dom.F90 that the length of a line exceeds that allowed by the Fortran standard (132 characters). This pull request breaks up that comment over two lines to get rid of that warning.

```
ifort -std08 -c m_dom_dom.F90
m_dom_dom.F90(9720): warning #5268: Extension to standard: The text exceeds right hand column allowed on the line.
! FIXME what if namespace is undeclared? Throw an error *only* if FoX_errors is on, otherwise its taken care of by namespace fixup on serialization
------------------------------------------------------------------------------------------------------------------------------------^
```
