### PR TITLE
removed the colon for each dimension in len functions arguments. 

### DIFF
--- a/fsys/fox_m_fsys_format.F90
+++ b/fsys/fox_m_fsys_format.F90
@@ -21,7 +21,7 @@ module fox_m_fsys_format
 !This bug made fail  all the _Overload  tests in wxml/tests. 
 ! safestr works correctly if  all colon are  removed  from the dimension 
 ! of the ia array arguments passed  to the len functions 
-!             (see e.g. lines 902 and below).
+!             (see e.g. lines 918 and below).
 ! With this format  it is instead ifort v.12 to fail, because of a similar and 
 ! opposite bug fortunately fixed by Intel in the successive  versions
 ! For sake of compatibility one or the other call is selected with 
@@ -915,7 +915,11 @@ contains
 #ifdef DUMMYLIB
     character(len=1) :: s
 #else
+#if defined (__PGI)
     character(len=len(ia, "d")) :: s
+#else
+    character(len=len(ia(:), "d")) :: s
+#endif
 
     integer :: j, k, n
  
@@ -937,7 +941,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ia, fmt)) :: s
+#else
+    character(len=len(ia(:), fmt)) :: s
+#endif
 
     integer :: j, k, n
 
@@ -957,7 +965,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ia, "d")) :: s
+#else
+    character(len=len(ia(:,:), "d")) :: s
+#endif
 
     integer :: j, k, n
 
@@ -984,7 +996,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ia, fmt)) :: s
+#else
+    character(len=len(ia(:,:), fmt)) :: s
+#endif
 
     integer :: j, k, n
 
@@ -1028,7 +1044,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(la)) :: s
+#else
+    character(len=len(la(:))) :: s
+#endif
 
     integer :: k, n
 
@@ -1057,7 +1077,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(la)) :: s
+#else
+    character(len=len(la(:,:))) :: s
+#endif
 
     integer :: j, k, n
 
@@ -1364,7 +1388,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa)) :: s
+#else
+    character(len=len(xa(:))) :: s
+#endif
 
     integer :: j, k, n
 
@@ -1382,7 +1410,11 @@ contains
   pure function str_real_sp_array_fmt(xa, fmt) result(s)
     real(sp), dimension(:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(xa, fmt)) :: s
+#else
+    character(len=len(xa(:), fmt)) :: s
+#endif
 
     integer :: j, k, n
 
@@ -1404,7 +1436,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa, fmt)) :: s
+#else
+    character(len=len(xa(:), fmt)) :: s
+#endif
 
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
@@ -1418,7 +1454,11 @@ contains
   pure function str_real_sp_matrix_fmt(xa, fmt) result(s)
     real(sp), dimension(:,:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(xa,fmt)) :: s
+#else
+    character(len=len(xa(:,:),fmt)) :: s
+#endif
 
     integer :: i, j, k, n
 
@@ -1448,7 +1488,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa,fmt)) :: s
+#else
+    character(len=len(xa(:,:),fmt)) :: s
+#endif
 
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
@@ -1464,7 +1508,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa)) :: s
+#else
+    character(len=len(xa(:,:))) :: s
+#endif
 
     s = safestr(xa, "")
 #endif
@@ -1695,7 +1743,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa)) :: s
+#else
+    character(len=len(xa(:))) :: s
+#endif
 
     integer :: j, k, n
 
@@ -1713,7 +1765,11 @@ contains
   pure function str_real_dp_array_fmt(xa, fmt) result(s)
     real(dp), dimension(:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(xa, fmt)) :: s
+#else
+    character(len=len(xa(:), fmt)) :: s
+#endif
 
     integer :: j, k, n
 
@@ -1735,8 +1791,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa, fmt)) :: s
-
+#else
+    character(len=len(xa(:), fmt)) :: s
+#endif
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
     else
@@ -1749,8 +1808,11 @@ contains
   function str_real_dp_matrix_fmt(xa, fmt) result(s)
     real(dp), dimension(:,:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(xa,fmt)) :: s
-
+#else
+    character(len=len(xa(:,:),fmt)) :: s
+#endif
     integer :: i, j, k, n
 
     i = len(xa(1,1), fmt)
@@ -1779,8 +1841,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa,fmt)) :: s
-
+#else
+    character(len=len(xa(:,:),fmt)) :: s
+#endif
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
     else
@@ -1795,7 +1860,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(xa)) :: s
+#else
+    character(len=len(xa(:,:))) :: s
+#endif
 
     s = safestr(xa, "")
 #endif
@@ -1854,7 +1923,11 @@ contains
   pure function str_complex_sp_array_fmt(ca, fmt) result(s)
     complex(sp), dimension(:), intent(in) :: ca
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:), fmt)) :: s
+#endif
 
     integer :: i, n
 
@@ -1874,7 +1947,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:), fmt)) :: s
+#endif
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -1890,7 +1967,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca)) :: s
+#else
+    character(len=len(ca(:))) :: s
+#endif
 
     s = safestr(ca, "")
 #endif
@@ -1900,7 +1981,11 @@ contains
   pure function str_complex_sp_matrix_fmt(ca, fmt) result(s)
     complex(sp), dimension(:, :), intent(in) :: ca
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:,:), fmt)) :: s
+#endif
 
     integer :: i, j, k, n
 
@@ -1930,7 +2015,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:,:), fmt)) :: s
+#endif
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -1946,7 +2035,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca)) :: s
+#else
+    character(len=len(ca(:,:))) :: s
+#endif
 
     s = safestr(ca, "")
 #endif
@@ -2001,7 +2094,11 @@ contains
   pure function str_complex_dp_array_fmt(ca, fmt) result(s)
     complex(dp), dimension(:), intent(in) :: ca
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:), fmt)) :: s
+#endif
 
     integer :: i, n
 
@@ -2021,7 +2118,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:), fmt)) :: s
+#endif
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -2037,7 +2138,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca)) :: s
+#else
+    character(len=len(ca(:))) :: s
+#endif
 
     s = safestr(ca, "")
 #endif
@@ -2047,7 +2152,11 @@ contains
   pure function str_complex_dp_matrix_fmt(ca, fmt) result(s)
     complex(dp), dimension(:, :), intent(in) :: ca
     character(len=*), intent(in) :: fmt
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:,:), fmt)) :: s
+#endif
 
     integer :: i, j, k, n
 
@@ -2077,7 +2186,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca, fmt)) :: s
+#else
+    character(len=len(ca(:,:), fmt)) :: s
+#endif
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -2093,7 +2206,11 @@ contains
     character(len=1) :: s
     s = " "
 #else
+#if defined(__PGI)
     character(len=len(ca)) :: s
+#else
+    character(len=len(ca(:,:))) :: s
+#endif
 
     s = safestr(ca, "")
 #endif

--- a/fsys/fox_m_fsys_format.F90
+++ b/fsys/fox_m_fsys_format.F90
@@ -902,10 +902,10 @@ contains
 #ifdef DUMMYLIB
     character(len=1) :: s
 #else
-    character(len=len(ia(:), "d")) :: s
+    character(len=len(ia, "d")) :: s
 
     integer :: j, k, n
-
+ 
     n = 1
     do k = 1, size(ia) - 1
       j = len(ia(k))
@@ -924,7 +924,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ia(:), fmt)) :: s
+    character(len=len(ia, fmt)) :: s
 
     integer :: j, k, n
 
@@ -944,7 +944,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ia(:,:), "d")) :: s
+    character(len=len(ia, "d")) :: s
 
     integer :: j, k, n
 
@@ -971,7 +971,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ia(:,:), fmt)) :: s
+    character(len=len(ia, fmt)) :: s
 
     integer :: j, k, n
 
@@ -1015,7 +1015,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(la(:))) :: s
+    character(len=len(la)) :: s
 
     integer :: k, n
 
@@ -1044,7 +1044,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(la(:,:))) :: s
+    character(len=len(la)) :: s
 
     integer :: j, k, n
 
@@ -1351,7 +1351,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:))) :: s
+    character(len=len(xa)) :: s
 
     integer :: j, k, n
 
@@ -1369,7 +1369,7 @@ contains
   pure function str_real_sp_array_fmt(xa, fmt) result(s)
     real(sp), dimension(:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
-    character(len=len(xa(:), fmt)) :: s
+    character(len=len(xa, fmt)) :: s
 
     integer :: j, k, n
 
@@ -1391,7 +1391,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:), fmt)) :: s
+    character(len=len(xa, fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
@@ -1405,7 +1405,7 @@ contains
   pure function str_real_sp_matrix_fmt(xa, fmt) result(s)
     real(sp), dimension(:,:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
-    character(len=len(xa(:,:),fmt)) :: s
+    character(len=len(xa,fmt)) :: s
 
     integer :: i, j, k, n
 
@@ -1435,7 +1435,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:,:),fmt)) :: s
+    character(len=len(xa,fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
@@ -1451,7 +1451,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:,:))) :: s
+    character(len=len(xa)) :: s
 
     s = safestr(xa, "")
 #endif
@@ -1682,7 +1682,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:))) :: s
+    character(len=len(xa)) :: s
 
     integer :: j, k, n
 
@@ -1700,7 +1700,7 @@ contains
   pure function str_real_dp_array_fmt(xa, fmt) result(s)
     real(dp), dimension(:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
-    character(len=len(xa(:), fmt)) :: s
+    character(len=len(xa, fmt)) :: s
 
     integer :: j, k, n
 
@@ -1722,7 +1722,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:), fmt)) :: s
+    character(len=len(xa, fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
@@ -1736,7 +1736,7 @@ contains
   function str_real_dp_matrix_fmt(xa, fmt) result(s)
     real(dp), dimension(:,:), intent(in) :: xa
     character(len=*), intent(in) :: fmt
-    character(len=len(xa(:,:),fmt)) :: s
+    character(len=len(xa,fmt)) :: s
 
     integer :: i, j, k, n
 
@@ -1766,7 +1766,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:,:),fmt)) :: s
+    character(len=len(xa,fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(xa, fmt)
@@ -1782,7 +1782,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(xa(:,:))) :: s
+    character(len=len(xa)) :: s
 
     s = safestr(xa, "")
 #endif
@@ -1841,7 +1841,7 @@ contains
   pure function str_complex_sp_array_fmt(ca, fmt) result(s)
     complex(sp), dimension(:), intent(in) :: ca
     character(len=*), intent(in) :: fmt
-    character(len=len(ca(:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     integer :: i, n
 
@@ -1861,7 +1861,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -1877,7 +1877,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:))) :: s
+    character(len=len(ca)) :: s
 
     s = safestr(ca, "")
 #endif
@@ -1887,7 +1887,7 @@ contains
   pure function str_complex_sp_matrix_fmt(ca, fmt) result(s)
     complex(sp), dimension(:, :), intent(in) :: ca
     character(len=*), intent(in) :: fmt
-    character(len=len(ca(:,:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     integer :: i, j, k, n
 
@@ -1917,7 +1917,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:,:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -1933,7 +1933,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:,:))) :: s
+    character(len=len(ca)) :: s
 
     s = safestr(ca, "")
 #endif
@@ -1988,7 +1988,7 @@ contains
   pure function str_complex_dp_array_fmt(ca, fmt) result(s)
     complex(dp), dimension(:), intent(in) :: ca
     character(len=*), intent(in) :: fmt
-    character(len=len(ca(:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     integer :: i, n
 
@@ -2008,7 +2008,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -2024,7 +2024,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:))) :: s
+    character(len=len(ca)) :: s
 
     s = safestr(ca, "")
 #endif
@@ -2034,7 +2034,7 @@ contains
   pure function str_complex_dp_matrix_fmt(ca, fmt) result(s)
     complex(dp), dimension(:, :), intent(in) :: ca
     character(len=*), intent(in) :: fmt
-    character(len=len(ca(:,:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     integer :: i, j, k, n
 
@@ -2064,7 +2064,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:,:), fmt)) :: s
+    character(len=len(ca, fmt)) :: s
 
     if (checkFmt(fmt)) then
       s = safestr(ca, fmt)
@@ -2080,7 +2080,7 @@ contains
     character(len=1) :: s
     s = " "
 #else
-    character(len=len(ca(:,:))) :: s
+    character(len=len(ca)) :: s
 
     s = safestr(ca, "")
 #endif

--- a/fsys/fox_m_fsys_format.F90
+++ b/fsys/fox_m_fsys_format.F90
@@ -14,6 +14,19 @@ module fox_m_fsys_format
 !to COUNT their length inline in the specification
 !expression, but Pathscale-2.4 gives an error on that.
 
+!With PGI (all versions up to last PGI 17.10 community edition)
+!all  the procedures exported with the safestr interface
+!were either crashing (older versions) or returning an empty string
+!(latest version) because of a compiler bug.  
+!This bug made fail  all the _Overload  tests in wxml/tests. 
+! safestr works correctly if  all colon are  removed  from the dimension 
+! of the ia array arguments passed  to the len functions 
+!             (see e.g. lines 902 and below).
+! With this format  it is instead ifort v.12 to fail, because of a similar and 
+! opposite bug fortunately fixed by Intel in the successive  versions
+! For sake of compatibility one or the other call is selected with 
+! preprocessor directives. 
+
   use fox_m_fsys_abort_flush, only: pxfflush
   use fox_m_fsys_realtypes, only: sp, dp
 


### PR DESCRIPTION
I don't know why but those colons were  making  pgi compiler produce bugged code which tried to allocate huge amount of memory anytime that a str function was called with an array argument.  