### PR TITLE
Initialize io

### DIFF
--- a/common/m_common_io.F90
+++ b/common/m_common_io.F90
@@ -11,6 +11,11 @@ module m_common_io
   integer, save :: io_eor
   integer, save :: io_eof
   integer, save :: io_err
+  logical, save :: io_init=.false.
+
+  interface  setup_io
+      module procedure setup_io_scratch, setup_io_with_data
+  end interface setup_io
 
   public :: io_eor
   public :: io_eof
@@ -20,9 +25,23 @@ module m_common_io
 
 contains
 
-  subroutine setup_io()
+  subroutine setup_io_scratch()
+    if (io_init) return 
     call find_eor_eof(io_eor, io_eof)
-  end subroutine setup_io
+    io_init = .true. 
+  end subroutine setup_io_scratch
+
+  subroutine setup_io_with_data(err_code, eor_code, eof_code)
+     implicit none
+     integer,intent(in)  :: err_code, eor_code, eof_code
+     if (io_init) return 
+     io_err = err_code
+     io_eor  = eor_code
+     io_eof  = eof_code
+     io_init = .true.
+   end subroutine setup_io_with_data 
+
+  
 
 
   subroutine get_unit(lun,iostat)

--- a/fsys/fox_m_fsys_abort_flush.F90
+++ b/fsys/fox_m_fsys_abort_flush.F90
@@ -104,7 +104,11 @@ CONTAINS
     i=>null()
     Print*,i
 #endif
+#if __GNUC__ == 4 && __GNUC_MINOR__ < 6 
+    stop 1  ! needed for gfortran < 4.6 to compile
+#else
     stop STDERR_FAILURE_STATUS
+#endif
 
   end subroutine pxfabort
 


### PR DESCRIPTION
The current setup_io opened a scratch file whenever a file was opened for reading. This may become cumbersome when the library is used in parallel MPI programs and has to read more then one file. 
I have added a flag in setup_io that is toggled to true as soon as setup_io initializes io_err, io_eor and io_eof, and on successive calls of setup_io the routine returns without performing any more test. 
I have also added the possibility to initialize the error codes by providing their values as arguments to setup_io. This can be useful in parallel application with one node that performs the test on the scratch file and then broadcasts the result to other nodes which will setup the error codes using the interface with the 3 err codes in input.  