### PR TITLE
Use intel module for abort and flush

### DIFF
--- a/fsys/fox_m_fsys_abort_flush.F90
+++ b/fsys/fox_m_fsys_abort_flush.F90
@@ -46,6 +46,9 @@ CONTAINS
 #ifdef __NAG__
     use f90_unix_io, only : flush
 #endif
+#ifdef __INTEL_COMPILER
+    use ifport, only : flush
+#endif
     integer, intent(in) :: unit
     integer :: i
 
@@ -78,6 +81,9 @@ CONTAINS
   subroutine pxfabort()
 #ifdef __NAG__
     use f90_unix_proc, only : abort
+#endif
+#ifdef __INTEL_COMPILER
+    use ifport, only : abort
 #endif
 #ifdef F2003
     interface


### PR DESCRIPTION
For the Intel compiler the functions Abort and Flush need to be used from ifport.